### PR TITLE
Change enum scope where conditions to hash args

### DIFF
--- a/lib/acts_as_enum.rb
+++ b/lib/acts_as_enum.rb
@@ -77,9 +77,9 @@ module ActsAsEnum
         const_set("#{method_name}".upcase, attr_value)
 
         if Rails.version =~ /^4/
-          scope method_name.to_sym, -> { where(["#{self.table_name}.#{attr} = ?", attr_value]) }
+          scope method_name.to_sym, -> { where(attr => attr_value) }
         elsif Rails.version =~ /^3/
-          scope method_name.to_sym, where(["#{self.table_name}.#{attr} = ?", attr_value])
+          scope method_name.to_sym, where(attr => attr_value])
         else
           named_scope method_name.to_sym, :conditions => { attr.to_sym => attr_value }
         end


### PR DESCRIPTION
auto assign enum attribute value for enum_scoped.new
for example: 
class User < ActiveRecord::Base
  acts_as_enum :status, in: [ ['disable', '冻结'], ['enable', '激活'] ] 
end
user = User.disable.new
user.status == 'disable' # => true
user = User.enable.new
user.status == 'enable' # => true